### PR TITLE
change var name to support terraform 0.12

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "deployment_minimum_healthy_percent" {
   description = "Minimum healthy percent of the service in the cluster"
 }
 
-variable depends_on {
+variable dependencies {
   default = []
 
   type = "list"


### PR DESCRIPTION
To check if your code is correct to upgrade from terraform 0.11.14 to terraform 0.12.x exists a command that indicates if your code is fine or not to upgrade it (terraform 0.12checklist).

In this module, the variable **depends_on** becomes reserved in terraform 0.12.x.

I've tested this change in local, and the result from the before command was correct.

Regards!